### PR TITLE
85 modify docker for add mailhog

### DIFF
--- a/.env
+++ b/.env
@@ -37,7 +37,7 @@ MESSENGER_TRANSPORT_DSN=doctrine://default?auto_setup=0
 ###< symfony/messenger ###
 
 ###> symfony/mailer ###
-MAILER_DSN=null://null
+MAILER_DSN=smtp://mailhog:1025
 ###< symfony/mailer ###
 
 ### Timezone ###

--- a/compose.yaml
+++ b/compose.yaml
@@ -26,7 +26,15 @@ services:
       - "127.0.0.1:5432:5432"
       # You may use a bind-mounted host directory instead, so that it is harder to accidentally remove the volume and lose all your data!
       # - ./docker/db/data:/var/lib/postgresql/data:rw
-###< doctrine/doctrine-bundle ###
+  ###< doctrine/doctrine-bundle ###
+
+  ###> symfony/mailhog ###
+  mailhog:
+    image: mailhog/mailhog
+    ports:
+      - "1025:1025"
+      - "8025:8025"
+  ###< symfony/mailhog ###
 
 volumes:
   ###> doctrine/doctrine-bundle ###


### PR DESCRIPTION
## ✅ MailHog Integration in Docker

### 📌 Summary:
This PR introduces **MailHog** to the Docker setup, allowing local email testing without external SMTP services.

### 🔧 Changes:
- Added **MailHog** service to `docker-compose.yml`
- Configured Symfony to use **MailHog** as the SMTP server in `.env`
- Updated documentation (`README.md`) with setup instructions

### 📌 How to Test:
1. Start Docker:  
   ```bash
   docker-compose up -d